### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 `npm start`
 
-Navigate to http://locathost:3001/
+Navigate to http://localhost:3001/


### PR DESCRIPTION
The example browser URL says 'locathost' instead of 'localhost'.